### PR TITLE
fix: update Homebrew installation command for gum in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ if ! command -v gum &> /dev/null; then
     if [[ "$OSTYPE" == "darwin"* ]]; then
       if command -v brew &> /dev/null; then
         echo "   Installing via Homebrew..."
-        brew install gum
+        brew install gum < /dev/null
       else
         echo "   ⚠️  Homebrew not found. Install manually: brew install gum"
       fi


### PR DESCRIPTION
Redirect input to /dev/null during Homebrew installation of gum to prevent potential hang issues.

Fixes #1 