### PR TITLE
Harden Ralph against headless hangs and orphaned processes + macOS fixes

### DIFF
--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -247,30 +247,29 @@ EOF
   # Initialize guardrails.md if it doesn't exist
   if [[ ! -f "$ralph_dir/guardrails.md" ]]; then
     cat > "$ralph_dir/guardrails.md" << 'EOF'
-# Ralph Guardrails (Signs)
+# Guardrails
 
-> Lessons learned from past failures. READ THESE BEFORE ACTING.
+> STOP. Read these before every action.
 
-## Core Signs
+## Non-Interactive Commands Only
 
-### Sign: Read Before Writing
-- **Trigger**: Before modifying any file
-- **Instruction**: Always read the existing file first
-- **Added after**: Core principle
+**NEVER** run commands that wait for input. Always use flags:
+- `npm init -y` (not `npm init`)
+- `git commit -m "msg"` (not `git commit`)
+- `python script.py` (not `python`)
+- `node script.js` (not `node`)
 
-### Sign: Test After Changes
-- **Trigger**: After any code change
-- **Instruction**: Run tests to verify nothing broke
-- **Added after**: Core principle
+## Safe Workflow
 
-### Sign: Commit Checkpoints
-- **Trigger**: Before risky changes
-- **Instruction**: Commit current working state first
-- **Added after**: Core principle
+1. **Read before write** - Check file contents before editing
+2. **Test after changes** - Run tests to verify
+3. **Commit checkpoints** - Save state before risky changes
 
 ---
 
-## Learned Signs
+## Learned Failures
+
+_(Added automatically when errors occur)_
 
 EOF
   fi
@@ -350,26 +349,49 @@ build_prompt() {
   local workspace="$1"
   local iteration="$2"
   
+  # Read guardrails and errors to inject directly
+  local guardrails=""
+  local errors=""
+  if [[ -f "$workspace/.ralph/guardrails.md" ]]; then
+    guardrails=$(cat "$workspace/.ralph/guardrails.md")
+  fi
+  if [[ -f "$workspace/.ralph/errors.log" ]]; then
+    errors=$(tail -30 "$workspace/.ralph/errors.log")
+  fi
+  
   cat << EOF
 # Ralph Iteration $iteration
 
-You are an autonomous development agent using the Ralph methodology.
+⚠️ **STOP! READ BEFORE ANY ACTION** ⚠️
 
-## FIRST: Read State Files
+1. Check if package.json exists BEFORE running npm init
+2. This is a git repo - do NOT run git init
+3. ALWAYS use: \`npm init -y\` (not \`npm init\`)
+4. ALWAYS use: \`git commit -m "msg"\` (not \`git commit\`)
 
-Before doing anything:
+**YOUR FIRST ACTION MUST BE: Read RALPH_TASK.md**
+
+---
+
+$guardrails
+
+## Recent Errors (From Previous Iterations)
+
+$errors
+
+## Read State Files
+
+Before coding:
 1. Read \`RALPH_TASK.md\` - your task and completion criteria
-2. Read \`.ralph/guardrails.md\` - lessons from past failures (FOLLOW THESE)
-3. Read \`.ralph/progress.md\` - what's been accomplished
-4. Read \`.ralph/errors.log\` - recent failures to avoid
+2. Read \`.ralph/progress.md\` - what's been accomplished
 
 ## Working Directory (Critical)
 
 You are already in a git repository. Work HERE, not in a subdirectory:
 
 - Do NOT run \`git init\` - the repo already exists
-- Do NOT run scaffolding commands that create nested directories (\`npx create-*\`, \`npm init\`, etc.)
-- If you need to scaffold, use flags like \`--no-git\` or scaffold into the current directory (\`.\`)
+- Do NOT run scaffolding commands that create nested directories (\`npx create-*\`)
+- Use \`npm init -y\` (with -y flag!) if you need to initialize a Node.js project
 - All code should live at the repo root or in subdirectories you create manually
 
 ## Git Protocol (Critical)
@@ -401,16 +423,9 @@ If you get rotated, the next agent picks up from your last commit. Your commits 
 ## Learning from Failures
 
 When something fails:
-1. Check \`.ralph/errors.log\` for failure history
-2. Figure out the root cause
-3. Add a Sign to \`.ralph/guardrails.md\` using this format:
-
-\`\`\`
-### Sign: [Descriptive Name]
-- **Trigger**: When this situation occurs
-- **Instruction**: What to do instead
-- **Added after**: Iteration $iteration - what happened
-\`\`\`
+1. Check \`.ralph/errors.log\` for what went wrong
+2. Add a one-line fix to \`.ralph/guardrails.md\` under "Learned Failures":
+   \`- [what went wrong] → [what to do instead]\`
 
 ## Context Rotation Warning
 

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -435,7 +435,17 @@ spinner() {
   local spin='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
   local i=0
   while true; do
-    printf "\r  🐛 Agent working... %s  (watch: tail -f %s/.ralph/activity.log)" "${spin:i++%${#spin}:1}" "$workspace" >&2
+    # Avoid line-wrapping (which creates "repeated" lines) by:
+    # - clearing the line every frame
+    # - showing a short, relative watch command
+    # - truncating to terminal width
+    local cols msg
+    cols="$(tput cols 2>/dev/null || echo 80)"
+    msg="  🐛 Agent working... ${spin:i++%${#spin}:1}  (watch: tail -f .ralph/activity.log)"
+    if [[ "$cols" =~ ^[0-9]+$ ]] && (( ${#msg} >= cols )); then
+      msg="${msg:0:cols-1}"
+    fi
+    printf "\r\033[2K%s" "$msg" >&2
     sleep 0.1
   done
 }

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -491,6 +491,17 @@ run_iteration() {
   # Start parser in background, reading from cursor-agent
   # Parser outputs to fifo, we read signals from fifo
   (
+    # Harden the execution environment against interactive commands.
+    # Also prepend shimmed binaries so calls like `npm init` cannot block.
+    export PATH="$script_dir/shims:$PATH"
+    export CI=1
+    export npm_config_yes=true
+    export npm_config_audit=false
+    export npm_config_fund=false
+    export GIT_TERMINAL_PROMPT=0
+    export GIT_EDITOR=:
+    export EDITOR=:
+    export PAGER=cat
     eval "$cmd \"$prompt\"" 2>&1 | "$script_dir/stream-parser.sh" "$workspace" > "$fifo"
   ) &
   local agent_pid=$!

--- a/scripts/shims/git
+++ b/scripts/shims/git
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph shim for git
+# - Prevents interactive editor launches (e.g., `git commit` without -m)
+# - Avoids interactive rebases
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+real_git() {
+  local filtered_path=""
+  local IFS=":"
+  for p in $PATH; do
+    [[ "$p" == "$WRAPPER_DIR" ]] && continue
+    filtered_path+="${filtered_path:+:}$p"
+  done
+  PATH="$filtered_path" command -v git || true
+}
+
+REAL_GIT="$(real_git)"
+if [[ -z "${REAL_GIT}" ]]; then
+  echo "ralph git shim: real git not found" >&2
+  exit 127
+fi
+
+subcmd="${1:-}"
+shift || true
+
+if [[ "$subcmd" == "rebase" ]]; then
+  for a in "$@"; do
+    if [[ "$a" == "-i" || "$a" == "--interactive" ]]; then
+      echo "ralph git shim: blocked interactive rebase (use non-interactive alternatives)" >&2
+      exit 2
+    fi
+  done
+fi
+
+if [[ "$subcmd" == "commit" ]]; then
+  has_msg=false
+  has_file=false
+  has_no_edit=false
+  has_amend=false
+  for a in "$@"; do
+    [[ "$a" == "-m" || "$a" == "--message" ]] && has_msg=true
+    [[ "$a" == "-F" || "$a" == "--file" ]] && has_file=true
+    [[ "$a" == "--no-edit" ]] && has_no_edit=true
+    [[ "$a" == "--amend" ]] && has_amend=true
+  done
+
+  # If amending without an explicit message, force --no-edit to avoid editor.
+  if [[ "$has_amend" == "true" && "$has_msg" == "false" && "$has_file" == "false" && "$has_no_edit" == "false" ]]; then
+    exec "$REAL_GIT" commit --no-edit "$@"
+  fi
+
+  # If committing without a message/file, add a default message to avoid editor.
+  if [[ "$has_msg" == "false" && "$has_file" == "false" ]]; then
+    exec "$REAL_GIT" commit -m "ralph: checkpoint" "$@"
+  fi
+fi
+
+exec "$REAL_GIT" "$subcmd" "$@"

--- a/scripts/shims/node
+++ b/scripts/shims/node
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph shim for node - blocks launching an interactive REPL.
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+real_node() {
+  local filtered_path=""
+  local IFS=":"
+  for p in $PATH; do
+    [[ "$p" == "$WRAPPER_DIR" ]] && continue
+    filtered_path+="${filtered_path:+:}$p"
+  done
+  PATH="$filtered_path" command -v node || true
+}
+
+REAL_NODE="$(real_node)"
+if [[ -z "${REAL_NODE}" ]]; then
+  echo "ralph node shim: real node not found" >&2
+  exit 127
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "ralph node shim: blocked interactive 'node' REPL (provide a script)" >&2
+  exit 2
+fi
+
+exec "$REAL_NODE" "$@"

--- a/scripts/shims/npm
+++ b/scripts/shims/npm
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph shim for npm
+# - Prevents interactive `npm init` from blocking the loop
+# - If package.json already exists, skips init entirely
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+real_npm() {
+  # Find the real npm by removing this shim dir from PATH
+  local filtered_path=""
+  local IFS=":"
+  for p in $PATH; do
+    [[ "$p" == "$WRAPPER_DIR" ]] && continue
+    filtered_path+="${filtered_path:+:}$p"
+  done
+  PATH="$filtered_path" command -v npm || true
+}
+
+REAL_NPM="$(real_npm)"
+if [[ -z "${REAL_NPM}" ]]; then
+  echo "ralph npm shim: real npm not found" >&2
+  exit 127
+fi
+
+subcmd="${1:-}"
+shift || true
+
+if [[ "$subcmd" == "init" ]]; then
+  # If package.json exists in the working directory, never run init.
+  if [[ -f "package.json" ]]; then
+    echo "ralph npm shim: package.json exists; skipping 'npm init' to avoid blocking/overwrites" >&2
+    exit 0
+  fi
+
+  # If this is initializer mode (npm init <initializer>), pass through unchanged.
+  # Example: npm init react-app myapp
+  if [[ "${1:-}" != "" && "${1:-}" != -* ]]; then
+    exec "$REAL_NPM" init "$@"
+  fi
+
+  # If caller already provided -y/--yes, pass through.
+  for a in "$@"; do
+    if [[ "$a" == "-y" || "$a" == "--yes" ]]; then
+      exec "$REAL_NPM" init "$@"
+    fi
+  done
+
+  # Default: make it non-interactive.
+  exec "$REAL_NPM" init -y "$@"
+fi
+
+exec "$REAL_NPM" "$subcmd" "$@"

--- a/scripts/shims/python
+++ b/scripts/shims/python
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph shim for python - blocks launching an interactive REPL.
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+real_python() {
+  local filtered_path=""
+  local IFS=":"
+  for p in $PATH; do
+    [[ "$p" == "$WRAPPER_DIR" ]] && continue
+    filtered_path+="${filtered_path:+:}$p"
+  done
+  PATH="$filtered_path" command -v python || true
+}
+
+REAL_PYTHON="$(real_python)"
+if [[ -z "${REAL_PYTHON}" ]]; then
+  echo "ralph python shim: real python not found" >&2
+  exit 127
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "ralph python shim: blocked interactive 'python' REPL (provide a script)" >&2
+  exit 2
+fi
+
+exec "$REAL_PYTHON" "$@"

--- a/scripts/shims/python3
+++ b/scripts/shims/python3
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ralph shim for python3 - blocks launching an interactive REPL.
+
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+real_python3() {
+  local filtered_path=""
+  local IFS=":"
+  for p in $PATH; do
+    [[ "$p" == "$WRAPPER_DIR" ]] && continue
+    filtered_path+="${filtered_path:+:}$p"
+  done
+  PATH="$filtered_path" command -v python3 || true
+}
+
+REAL_PYTHON3="$(real_python3)"
+if [[ -z "${REAL_PYTHON3}" ]]; then
+  echo "ralph python3 shim: real python3 not found" >&2
+  exit 127
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "ralph python3 shim: blocked interactive 'python3' REPL (provide a script)" >&2
+  exit 2
+fi
+
+exec "$REAL_PYTHON3" "$@"

--- a/scripts/stream-parser.sh
+++ b/scripts/stream-parser.sh
@@ -302,6 +302,9 @@ main() {
   echo "Ralph Session Started: $(date)" >> "$RALPH_DIR/activity.log"
   echo "═══════════════════════════════════════════════════════════════" >> "$RALPH_DIR/activity.log"
   
+  # Debug: log that we're starting to read
+  echo "[$(date '+%H:%M:%S')] DEBUG: stream-parser started, waiting for input..." >> "$RALPH_DIR/activity.log"
+  
   # Track last token log time
   local last_token_log=$(date +%s)
   


### PR DESCRIPTION
## Summary

This PR hardens the Ralph loop against “ghost processes” and headless hangs caused by interactive commands.

- Kill the full agent process tree on `ROTATE` / `GUTTER` / `COMPLETE` to avoid orphaned `cursor-agent` / parser processes.
- Add a watchdog that monitors the agent’s descendant processes and triggers `GUTTER` when it detects blocking interactive commands (e.g. `npm init`, `git commit` without `-m`, `python`/`node` REPL).
- Add command shims + non-interactive environment hardening:
  - `npm init` becomes non-blocking (`npm init -y`), and is skipped if `package.json` already exists.
  - `git commit` no longer opens an editor (default message / `--no-edit` for amend).
  - `python` / `node` without args is blocked to prevent REPL hangs.
- Stream parser improvements:
  - Detect common interactive shell commands early and signal `GUTTER`.
  - Log a startup debug line in `activity.log` to confirm the parser is running.
- Spinner rendering fix: prevent line wrapping/repeating by clearing the line each frame and truncating to terminal width.

## Test plan

- Run `scripts/ralph-setup.sh` in a repo with a task that typically triggers `npm init`.
  - Confirm the loop does not hang and the run continues.
  - Confirm `activity.log` contains the stream-parser startup line.
- Confirm `git commit` does not open an editor during the run.
- Confirm the spinner stays on a single line (no repeated wrapped lines).

## Notes

- Shims are injected only for the agent subprocess via `PATH` prepending; they do not change the user’s global environment.