### PR TITLE
feat: migrate from Cursor to Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ralph Wiggum for Cursor
+# Ralph Wiggum for Claude Code
 
-An implementation of [Geoffrey Huntley's Ralph Wiggum technique](https://ghuntley.com/ralph/) for Cursor, enabling autonomous AI development with deliberate context management.
+An implementation of [Geoffrey Huntley's Ralph Wiggum technique](https://ghuntley.com/ralph/) for Claude Code CLI, enabling autonomous AI development with deliberate context management.
 
 > "That's the beauty of Ralph - the technique is deterministically bad in an undeterministic world."
 
@@ -47,7 +47,7 @@ This creates two problems:
 │              │                         │                    │
 │              └────────────┬────────────┘                    │
 │                           ▼                                  │
-│    cursor-agent -p --force --output-format stream-json       │
+│    claude -p --verbose --output-format stream-json            │
 │                           │                                  │
 │                           ▼                                  │
 │                   stream-parser.sh                           │
@@ -77,7 +77,7 @@ This creates two problems:
 | Requirement | Check | How to Set Up |
 |-------------|-------|---------------|
 | **Git repo** | `git status` works | `git init` |
-| **cursor-agent CLI** | `which cursor-agent` | `curl https://cursor.com/install -fsS \| bash` |
+| **claude CLI** | `which claude` | `npm install -g @anthropic-ai/claude-code` |
 | **gum** (optional) | `which gum` | Installer offers to install, or `brew install gum` |
 
 ## Quick Start
@@ -92,7 +92,7 @@ curl -fsSL https://raw.githubusercontent.com/agrimsingh/ralph-wiggum-cursor/main
 This creates:
 ```
 your-project/
-├── .cursor/ralph-scripts/      # Ralph scripts
+├── .claude/ralph-scripts/      # Ralph scripts
 │   ├── ralph-setup.sh          # Main entry point (interactive)
 │   ├── ralph-loop.sh           # CLI mode (for scripting)
 │   ├── ralph-once.sh           # Single iteration (testing)
@@ -117,10 +117,9 @@ With gum, you get a beautiful interactive menu for selecting models and options:
 
 ```
 ? Select model:
-  ◉ opus-4.5-thinking
-  ◯ sonnet-4.5-thinking
-  ◯ gpt-5.2-high
-  ◯ composer-1
+  ◉ opus
+  ◯ sonnet
+  ◯ haiku
   ◯ Custom...
 
 ? Max iterations: 20
@@ -166,12 +165,12 @@ Build a REST API with user management.
 ### 4. Start the Loop
 
 ```bash
-./.cursor/ralph-scripts/ralph-setup.sh
+./.claude/ralph-scripts/ralph-setup.sh
 ```
 
 Ralph will:
 1. Show interactive UI for model and options (or simple prompts if gum not installed)
-2. Run `cursor-agent` with your task
+2. Run `claude CLI` with your task
 3. Parse output in real-time, tracking token usage
 4. At 70k tokens: warn agent to wrap up current work
 5. At 80k tokens: rotate to fresh context
@@ -209,7 +208,7 @@ cat .ralph/errors.log
 
 Options:
   -n, --iterations N     Max iterations (default: 20)
-  -m, --model MODEL      Model to use (default: opus-4.5-thinking)
+  -m, --model MODEL      Model to use (default: opus)
   --branch NAME          Create and work on a new branch
   --pr                   Open PR when complete (requires --branch)
   -y, --yes              Skip confirmation prompt
@@ -222,7 +221,7 @@ Options:
 ./ralph-loop.sh --branch feature/api --pr -y
 
 # Use a different model with more iterations
-./ralph-loop.sh -n 50 -m gpt-5.2-high
+./ralph-loop.sh -n 50 -m sonnet
 ```
 
 ## How It Works
@@ -345,10 +344,10 @@ Configuration is set via command-line flags or environment variables:
 
 ```bash
 # Via flags (recommended)
-./ralph-loop.sh -n 50 -m gpt-5.2-high
+./ralph-loop.sh -n 50 -m sonnet
 
 # Via environment
-RALPH_MODEL=gpt-5.2-high MAX_ITERATIONS=50 ./ralph-loop.sh
+RALPH_MODEL=sonnet MAX_ITERATIONS=50 ./ralph-loop.sh
 ```
 
 Default thresholds in `ralph-common.sh`:
@@ -361,10 +360,10 @@ ROTATE_THRESHOLD=80000  # Tokens: force rotation
 
 ## Troubleshooting
 
-### "cursor-agent CLI not found"
+### "claude CLI not found"
 
 ```bash
-curl https://cursor.com/install -fsS | bash
+npm install -g @anthropic-ai/claude-code
 ```
 
 ### Agent keeps failing on same thing
@@ -412,13 +411,14 @@ Check if criteria are too vague. Each criterion should be:
 
 - [Original Ralph technique](https://ghuntley.com/ralph/) - Geoffrey Huntley
 - [Context as memory](https://ghuntley.com/allocations/) - The malloc/free metaphor
-- [Cursor CLI docs](https://cursor.com/docs/cli/headless)
+- [Claude Code CLI docs](https://code.claude.com/docs/en/cli-reference)
 - [gum - A tool for glamorous shell scripts](https://github.com/charmbracelet/gum)
 
 ## Credits
 
 - **Original technique**: [Geoffrey Huntley](https://ghuntley.com/ralph/) - the Ralph Wiggum methodology
-- **Cursor port**: [Agrim Singh](https://x.com/agrimsingh) - this implementation
+- **Cursor port**: [Agrim Singh](https://x.com/agrimsingh) - original cursor implementation
+- **Claude Code port**: Fork adapted for Claude Code CLI
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This creates two problems:
 
 ```bash
 cd your-project
-curl -fsSL https://raw.githubusercontent.com/agrimsingh/ralph-wiggum-cursor/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/jfriv/ralph-wiggum-claudecode/refs/heads/jfriv-claude-code/install.sh | bash
 ```
 
 This creates:

--- a/install.sh
+++ b/install.sh
@@ -263,10 +263,18 @@ if [[ -f "$GIT_ROOT/.gitignore" ]]; then
     echo "# Ralph config (may contain API key)" >> "$GIT_ROOT/.gitignore"
     echo ".claude/ralph-config.json" >> "$GIT_ROOT/.gitignore"
   fi
+  if ! grep -q "agent-output.log" "$GIT_ROOT/.gitignore" 2>/dev/null; then
+    echo "" >> "$GIT_ROOT/.gitignore"
+    echo "# Ralph agent output log (large, not useful in git)" >> "$GIT_ROOT/.gitignore"
+    echo ".ralph/agent-output.log" >> "$GIT_ROOT/.gitignore"
+  fi
 else
   cat > "$GIT_ROOT/.gitignore" <<'EOF'
 # Ralph config (may contain API key)
 .claude/ralph-config.json
+
+# Ralph agent output log (large, not useful in git)
+.ralph/agent-output.log
 EOF
 fi
 echo "✓ Updated .gitignore"

--- a/install.sh
+++ b/install.sh
@@ -265,16 +265,18 @@ if [[ -f "$GIT_ROOT/.gitignore" ]]; then
   fi
   if ! grep -q "agent-output.log" "$GIT_ROOT/.gitignore" 2>/dev/null; then
     echo "" >> "$GIT_ROOT/.gitignore"
-    echo "# Ralph agent output log (large, not useful in git)" >> "$GIT_ROOT/.gitignore"
+    echo "# Ralph logs (large, not useful in git)" >> "$GIT_ROOT/.gitignore"
     echo ".ralph/agent-output.log" >> "$GIT_ROOT/.gitignore"
+    echo ".ralph/activity.log" >> "$GIT_ROOT/.gitignore"
   fi
 else
   cat > "$GIT_ROOT/.gitignore" <<'EOF'
 # Ralph config (may contain API key)
 .claude/ralph-config.json
 
-# Ralph agent output log (large, not useful in git)
+# Ralph logs (large, not useful in git)
 .ralph/agent-output.log
+.ralph/activity.log
 EOF
 fi
 echo "✓ Updated .gitignore"

--- a/install.sh
+++ b/install.sh
@@ -20,10 +20,10 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
   echo ""
 fi
 
-# Check for cursor-agent CLI
-if ! command -v cursor-agent &> /dev/null; then
-  echo "⚠️  Warning: cursor-agent CLI not found."
-  echo "   Install via: curl https://cursor.com/install -fsS | bash"
+# Check for claude CLI
+if ! command -v claude &> /dev/null; then
+  echo "⚠️  Warning: claude CLI not found."
+  echo "   Install via: npm install -g @anthropic-ai/claude-code"
   echo ""
 fi
 
@@ -78,7 +78,7 @@ WORKSPACE_ROOT="$(pwd)"
 # =============================================================================
 
 echo "📁 Creating directories..."
-mkdir -p .cursor/ralph-scripts
+mkdir -p .claude/ralph-scripts
 mkdir -p .ralph
 
 # =============================================================================
@@ -97,14 +97,14 @@ SCRIPTS=(
 )
 
 for script in "${SCRIPTS[@]}"; do
-  if curl -fsSL "$REPO_RAW/scripts/$script" -o ".cursor/ralph-scripts/$script" 2>/dev/null; then
-    chmod +x ".cursor/ralph-scripts/$script"
+  if curl -fsSL "$REPO_RAW/scripts/$script" -o ".claude/ralph-scripts/$script" 2>/dev/null; then
+    chmod +x ".claude/ralph-scripts/$script"
   else
     echo "   ⚠️  Could not download $script (may not exist yet)"
   fi
 done
 
-echo "✓ Scripts installed to .cursor/ralph-scripts/"
+echo "✓ Scripts installed to .claude/ralph-scripts/"
 
 
 # =============================================================================
@@ -250,12 +250,12 @@ if [[ -f ".gitignore" ]]; then
   if ! grep -q "ralph-config.json" .gitignore 2>/dev/null; then
     echo "" >> .gitignore
     echo "# Ralph config (may contain API key)" >> .gitignore
-    echo ".cursor/ralph-config.json" >> .gitignore
+    echo ".claude/ralph-config.json" >> .gitignore
   fi
 else
   cat > .gitignore <<'EOF'
 # Ralph config (may contain API key)
-.cursor/ralph-config.json
+.claude/ralph-config.json
 EOF
 fi
 echo "✓ Updated .gitignore"
@@ -271,7 +271,7 @@ echo "════════════════════════�
 echo ""
 echo "Files created:"
 echo ""
-echo "  📁 .cursor/ralph-scripts/"
+echo "  📁 .claude/ralph-scripts/"
 echo "     ├── ralph-setup.sh          - Main entry (interactive)"
 echo "     ├── ralph-loop.sh           - CLI mode (for scripting)"
 echo "     ├── ralph-once.sh           - Single iteration (testing)"
@@ -287,7 +287,7 @@ echo "  📄 RALPH_TASK.md               - Your task definition (edit this!)"
 echo ""
 echo "Next steps:"
 echo "  1. Edit RALPH_TASK.md to define your actual task"
-echo "  2. Run: ./.cursor/ralph-scripts/ralph-setup.sh"
+echo "  2. Run: ./.claude/ralph-scripts/ralph-setup.sh"
 echo ""
 echo "Alternative commands:"
 echo "  • ralph-once.sh    - Test with single iteration first"

--- a/install.sh
+++ b/install.sh
@@ -180,6 +180,14 @@ cat > .ralph/activity.log << 'EOF'
 
 EOF
 
+cat > .ralph/agent-output.log << 'EOF'
+# Agent Output Log
+
+> Raw JSON output from the agent CLI (claude or cursor-agent).
+> Use this for debugging and analysis.
+
+EOF
+
 echo "0" > .ralph/.iteration
 
 echo "✓ .ralph/ initialized"
@@ -284,6 +292,7 @@ echo "  📁 .ralph/                     - State files (tracked in git)"
 echo "     ├── guardrails.md           - Lessons learned"
 echo "     ├── progress.md             - Progress log"
 echo "     ├── activity.log            - Tool call log"
+echo "     ├── agent-output.log        - Raw agent JSON output"
 echo "     └── errors.log              - Failure log"
 echo ""
 echo "  📄 RALPH_TASK.md               - Your task definition (edit this!)"

--- a/install.sh
+++ b/install.sh
@@ -13,10 +13,18 @@ echo ""
 
 # Check if we're in a git repo
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
-  echo "⚠️  Warning: Not in a git repository."
-  echo "   Ralph works best with git for state persistence."
+  echo "❌ Not in a git repository."
+  echo "   Ralph requires git for state persistence."
   echo ""
   echo "   Run: git init"
+  exit 1
+fi
+
+# Navigate to git root if in a subdirectory
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$PWD" != "$GIT_ROOT" ]]; then
+  echo "📂 Moving to git root: $GIT_ROOT"
+  cd "$GIT_ROOT"
   echo ""
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -20,12 +20,8 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
   exit 1
 fi
 
-# Navigate to git root if in a subdirectory
+# Get git root for .gitignore updates
 GIT_ROOT="$(git rev-parse --show-toplevel)"
-if [[ "$PWD" != "$GIT_ROOT" ]]; then
-  echo "📂 Using git root: $GIT_ROOT"
-  echo ""
-fi
 
 # Check for claude CLI
 if ! command -v claude &> /dev/null; then
@@ -254,13 +250,13 @@ fi
 # =============================================================================
 
 if [[ -f "$GIT_ROOT/.gitignore" ]]; then
-  if ! grep -q "ralph-config.json" .gitignore 2>/dev/null; then
-    echo "" >> $GIT_ROOT/.gitignore
-    echo "# Ralph config (may contain API key)" >> $GIT_ROOT/.gitignore
-    echo ".claude/ralph-config.json" >> $GIT_ROOT/.gitignore
+  if ! grep -q "ralph-config.json" "$GIT_ROOT/.gitignore" 2>/dev/null; then
+    echo "" >> "$GIT_ROOT/.gitignore"
+    echo "# Ralph config (may contain API key)" >> "$GIT_ROOT/.gitignore"
+    echo ".claude/ralph-config.json" >> "$GIT_ROOT/.gitignore"
   fi
 else
-  cat > $GIT_ROOT/.gitignore <<'EOF'
+  cat > "$GIT_ROOT/.gitignore" <<'EOF'
 # Ralph config (may contain API key)
 .claude/ralph-config.json
 EOF

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # Ralph Wiggum: One-click installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/agrimsingh/ralph-wiggum-cursor/main/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/jfriv/ralph-wiggum-claudecode/jfriv-claude-code/install.sh | bash
 
 set -euo pipefail
 
-REPO_RAW="https://raw.githubusercontent.com/agrimsingh/ralph-wiggum-cursor/main"
+REPO_RAW="https://raw.githubusercontent.com/jfriv/ralph-wiggum-claudecode/jfriv-claude-code"
 
 echo "═══════════════════════════════════════════════════════════════════"
 echo "🐛 Ralph Wiggum Installer"

--- a/install.sh
+++ b/install.sh
@@ -23,8 +23,7 @@ fi
 # Navigate to git root if in a subdirectory
 GIT_ROOT="$(git rev-parse --show-toplevel)"
 if [[ "$PWD" != "$GIT_ROOT" ]]; then
-  echo "📂 Moving to git root: $GIT_ROOT"
-  cd "$GIT_ROOT"
+  echo "📂 Using git root: $GIT_ROOT"
   echo ""
 fi
 
@@ -254,14 +253,14 @@ fi
 # UPDATE .gitignore
 # =============================================================================
 
-if [[ -f ".gitignore" ]]; then
+if [[ -f "$GIT_ROOT/.gitignore" ]]; then
   if ! grep -q "ralph-config.json" .gitignore 2>/dev/null; then
-    echo "" >> .gitignore
-    echo "# Ralph config (may contain API key)" >> .gitignore
-    echo ".claude/ralph-config.json" >> .gitignore
+    echo "" >> $GIT_ROOT/.gitignore
+    echo "# Ralph config (may contain API key)" >> $GIT_ROOT/.gitignore
+    echo ".claude/ralph-config.json" >> $GIT_ROOT/.gitignore
   fi
 else
-  cat > .gitignore <<'EOF'
+  cat > $GIT_ROOT/.gitignore <<'EOF'
 # Ralph config (may contain API key)
 .claude/ralph-config.json
 EOF

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -170,11 +170,19 @@ if [[ -f ".gitignore" ]]; then
     echo "# Ralph config (may contain API keys)" >> .gitignore
     echo ".claude/ralph-config.json" >> .gitignore
   fi
+  if ! grep -q "agent-output.log" .gitignore; then
+    echo "" >> .gitignore
+    echo "# Ralph agent output log (large, not useful in git)" >> .gitignore
+    echo ".ralph/agent-output.log" >> .gitignore
+  fi
   echo "✓ Updated .gitignore"
 else
   cat > .gitignore << 'EOF'
 # Ralph config (may contain API keys)
 .claude/ralph-config.json
+
+# Ralph agent output log (large, not useful in git)
+.ralph/agent-output.log
 EOF
   echo "✓ Created .gitignore"
 fi

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -24,16 +24,16 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
   fi
 fi
 
-# Check for cursor-agent CLI
-if ! command -v cursor-agent &> /dev/null; then
-  echo "⚠️  Warning: cursor-agent CLI not found."
-  echo "   Install via: curl https://cursor.com/install -fsS | bash"
+# Check for claude CLI
+if ! command -v claude &> /dev/null; then
+  echo "⚠️  Warning: claude CLI not found."
+  echo "   Install via: npm install -g @anthropic-ai/claude-code"
   echo ""
 fi
 
 # Create directories
 mkdir -p .ralph
-mkdir -p .cursor/ralph-scripts
+mkdir -p .claude/ralph-scripts
 
 # =============================================================================
 # CREATE RALPH_TASK.md IF NOT EXISTS
@@ -149,10 +149,10 @@ echo "0" > .ralph/.iteration
 echo "📦 Installing scripts..."
 
 # Copy scripts
-cp "$SKILL_DIR/scripts/"*.sh .cursor/ralph-scripts/ 2>/dev/null || true
-chmod +x .cursor/ralph-scripts/*.sh 2>/dev/null || true
+cp "$SKILL_DIR/scripts/"*.sh .claude/ralph-scripts/ 2>/dev/null || true
+chmod +x .claude/ralph-scripts/*.sh 2>/dev/null || true
 
-echo "✓ Scripts installed to .cursor/ralph-scripts/"
+echo "✓ Scripts installed to .claude/ralph-scripts/"
 
 # =============================================================================
 # UPDATE .gitignore
@@ -163,13 +163,13 @@ if [[ -f ".gitignore" ]]; then
   if ! grep -q "ralph-config.json" .gitignore; then
     echo "" >> .gitignore
     echo "# Ralph config (may contain API keys)" >> .gitignore
-    echo ".cursor/ralph-config.json" >> .gitignore
+    echo ".claude/ralph-config.json" >> .gitignore
   fi
   echo "✓ Updated .gitignore"
 else
   cat > .gitignore << 'EOF'
 # Ralph config (may contain API keys)
-.cursor/ralph-config.json
+.claude/ralph-config.json
 EOF
   echo "✓ Created .gitignore"
 fi
@@ -193,7 +193,7 @@ echo ""
 echo "Next steps:"
 echo "  1. Edit RALPH_TASK.md to define your task and criteria"
 echo "  2. Run: ./scripts/ralph-loop.sh"
-echo "     (or: .cursor/ralph-scripts/ralph-loop.sh)"
+echo "     (or: .claude/ralph-scripts/ralph-loop.sh)"
 echo ""
 echo "The agent will work autonomously, rotating context as needed."
 echo "Monitor progress: tail -f .ralph/activity.log"

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -137,6 +137,14 @@ cat > .ralph/activity.log << 'EOF'
 
 EOF
 
+cat > .ralph/agent-output.log << 'EOF'
+# Agent Output Log
+
+> Raw JSON output from the agent CLI (claude or cursor-agent).
+> Use this for debugging and analysis.
+
+EOF
+
 echo "0" > .ralph/.iteration
 
 # =============================================================================
@@ -181,11 +189,12 @@ echo "✅ Ralph initialized!"
 echo "═══════════════════════════════════════════════════════════════════"
 echo ""
 echo "Files created:"
-echo "  • RALPH_TASK.md        - Define your task here"
-echo "  • .ralph/guardrails.md - Lessons learned (agent updates this)"
-echo "  • .ralph/progress.md   - Progress log (agent updates this)"
-echo "  • .ralph/activity.log  - Tool call log (parser updates this)"
-echo "  • .ralph/errors.log    - Failure log (parser updates this)"
+echo "  • RALPH_TASK.md             - Define your task here"
+echo "  • .ralph/guardrails.md      - Lessons learned (agent updates this)"
+echo "  • .ralph/progress.md        - Progress log (agent updates this)"
+echo "  • .ralph/activity.log       - Tool call log (parser updates this)"
+echo "  • .ralph/agent-output.log   - Raw agent JSON output"
+echo "  • .ralph/errors.log         - Failure log (parser updates this)"
 echo ""
 echo "Next steps:"
 echo "  1. Edit RALPH_TASK.md to define your task and criteria"

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -14,14 +14,19 @@ echo ""
 
 # Check if we're in a git repo
 if ! git rev-parse --git-dir > /dev/null 2>&1; then
-  echo "⚠️  Warning: Not in a git repository."
-  echo "   Ralph works best with git for state persistence."
+  echo "❌ Not in a git repository."
+  echo "   Ralph requires git for state persistence."
   echo ""
-  read -p "Continue anyway? [y/N] " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    exit 1
-  fi
+  echo "   Run: git init"
+  exit 1
+fi
+
+# Navigate to git root if in a subdirectory
+GIT_ROOT="$(git rev-parse --show-toplevel)"
+if [[ "$PWD" != "$GIT_ROOT" ]]; then
+  echo "📂 Moving to git root: $GIT_ROOT"
+  cd "$GIT_ROOT"
+  echo ""
 fi
 
 # Check for claude CLI

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -21,14 +21,6 @@ if ! git rev-parse --git-dir > /dev/null 2>&1; then
   exit 1
 fi
 
-# Navigate to git root if in a subdirectory
-GIT_ROOT="$(git rev-parse --show-toplevel)"
-if [[ "$PWD" != "$GIT_ROOT" ]]; then
-  echo "📂 Moving to git root: $GIT_ROOT"
-  cd "$GIT_ROOT"
-  echo ""
-fi
-
 # Check for claude CLI
 if ! command -v claude &> /dev/null; then
   echo "⚠️  Warning: claude CLI not found."

--- a/scripts/init-ralph.sh
+++ b/scripts/init-ralph.sh
@@ -172,8 +172,9 @@ if [[ -f ".gitignore" ]]; then
   fi
   if ! grep -q "agent-output.log" .gitignore; then
     echo "" >> .gitignore
-    echo "# Ralph agent output log (large, not useful in git)" >> .gitignore
+    echo "# Ralph logs (large, not useful in git)" >> .gitignore
     echo ".ralph/agent-output.log" >> .gitignore
+    echo ".ralph/activity.log" >> .gitignore
   fi
   echo "✓ Updated .gitignore"
 else
@@ -181,8 +182,9 @@ else
 # Ralph config (may contain API keys)
 .claude/ralph-config.json
 
-# Ralph agent output log (large, not useful in git)
+# Ralph logs (large, not useful in git)
 .ralph/agent-output.log
+.ralph/activity.log
 EOF
   echo "✓ Created .gitignore"
 fi

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -381,7 +381,7 @@ run_iteration() {
   log_progress "$workspace" "**Session $iteration started** (model: $MODEL)"
   
   # Build claude CLI command
-  local cmd="claude -p --verbose --output-format stream-json --model $MODEL"
+  local cmd="claude -p --verbose --output-format stream-json --dangerously-skip-permissions --model $MODEL"
   
   if [[ -n "$session_id" ]]; then
     echo "Resuming session: $session_id" >&2

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -270,6 +270,17 @@ EOF
 
 EOF
   fi
+
+  # Initialize agent-output.log if it doesn't exist
+  if [[ ! -f "$ralph_dir/agent-output.log" ]]; then
+    cat > "$ralph_dir/agent-output.log" << 'EOF'
+# Agent Output Log
+
+> Raw JSON output from the agent CLI (claude or cursor-agent).
+> Use this for debugging and analysis.
+
+EOF
+  fi
 }
 
 # =============================================================================

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -72,6 +72,24 @@ ralph_interrupt_handler() {
 # BASIC HELPERS
 # =============================================================================
 
+# Get git root for a directory, or exit with error if not in a git repo
+# Usage: workspace=$(resolve_git_root "$workspace")
+resolve_git_root() {
+  local dir="${1:-.}"
+
+  # Check if in a git repo
+  if ! git -C "$dir" rev-parse --git-dir > /dev/null 2>&1; then
+    echo "❌ Not in a git repository: $dir" >&2
+    echo "   Ralph requires git for state persistence." >&2
+    echo "" >&2
+    echo "   Run: git init" >&2
+    return 1
+  fi
+
+  # Return the git root
+  git -C "$dir" rev-parse --show-toplevel
+}
+
 # Cross-platform sed -i
 sedi() {
   if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -90,24 +90,6 @@ trap ralph_cleanup EXIT
 # BASIC HELPERS
 # =============================================================================
 
-# Get git root for a directory, or exit with error if not in a git repo
-# Usage: workspace=$(resolve_git_root "$workspace")
-resolve_git_root() {
-  local dir="${1:-.}"
-
-  # Check if in a git repo
-  if ! git -C "$dir" rev-parse --git-dir > /dev/null 2>&1; then
-    echo "❌ Not in a git repository: $dir" >&2
-    echo "   Ralph requires git for state persistence." >&2
-    echo "" >&2
-    echo "   Run: git init" >&2
-    return 1
-  fi
-
-  # Return the git root
-  git -C "$dir" rev-parse --show-toplevel
-}
-
 # Cross-platform sed -i
 sedi() {
   if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -16,7 +16,7 @@ ROTATE_THRESHOLD="${ROTATE_THRESHOLD:-80000}"
 MAX_ITERATIONS="${MAX_ITERATIONS:-20}"
 
 # Model selection
-DEFAULT_MODEL="opus-4.5-thinking"
+DEFAULT_MODEL="opus"
 MODEL="${RALPH_MODEL:-$DEFAULT_MODEL}"
 
 # Feature flags (set by caller)
@@ -380,12 +380,12 @@ run_iteration() {
   # Log session start to progress.md
   log_progress "$workspace" "**Session $iteration started** (model: $MODEL)"
   
-  # Build cursor-agent command
-  local cmd="cursor-agent -p --force --output-format stream-json --model $MODEL"
+  # Build claude CLI command
+  local cmd="claude -p --verbose --output-format stream-json --model $MODEL"
   
   if [[ -n "$session_id" ]]; then
     echo "Resuming session: $session_id" >&2
-    cmd="$cmd --resume=\"$session_id\""
+    cmd="$cmd -r \"$session_id\""
   fi
   
   # Change to workspace
@@ -395,7 +395,7 @@ run_iteration() {
   spinner "$workspace" &
   local spinner_pid=$!
   
-  # Start parser in background, reading from cursor-agent
+  # Start parser in background, reading from claude CLI
   # Parser outputs to fifo, we read signals from fifo
   (
     eval "$cmd \"$prompt\"" 2>&1 | "$script_dir/stream-parser.sh" "$workspace" > "$fifo"
@@ -618,12 +618,12 @@ check_prerequisites() {
     return 1
   fi
   
-  # Check for cursor-agent CLI
-  if ! command -v cursor-agent &> /dev/null; then
-    echo "❌ cursor-agent CLI not found"
+  # Check for claude CLI
+  if ! command -v claude &> /dev/null; then
+    echo "❌ claude CLI not found"
     echo ""
     echo "Install via:"
-    echo "  curl https://cursor.com/install -fsS | bash"
+    echo "  npm install -g @anthropic-ai/claude-code"
     return 1
   fi
   

--- a/scripts/ralph-loop.sh
+++ b/scripts/ralph-loop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Ralph Wiggum: The Loop (CLI Mode)
 #
-# Runs cursor-agent locally with stream-json parsing for accurate token tracking.
+# Runs claude CLI locally with stream-json parsing for accurate token tracking.
 # Handles context rotation via --resume when thresholds are hit.
 #
 # This script is for power users and scripting. For interactive use, see ralph-setup.sh.
@@ -9,13 +9,13 @@
 # Usage:
 #   ./ralph-loop.sh                              # Start from current directory
 #   ./ralph-loop.sh /path/to/project             # Start from specific project
-#   ./ralph-loop.sh -n 50 -m gpt-5.2-high        # Custom iterations and model
+#   ./ralph-loop.sh -n 50 -m opus                # Custom iterations and model
 #   ./ralph-loop.sh --branch feature/foo --pr   # Create branch and PR
 #   ./ralph-loop.sh -y                           # Skip confirmation (for scripting)
 #
 # Flags:
 #   -n, --iterations N     Max iterations (default: 20)
-#   -m, --model MODEL      Model to use (default: opus-4.5-thinking)
+#   -m, --model MODEL      Model to use (default: opus)
 #   --branch NAME          Create and work on a new branch
 #   --pr                   Open PR when complete (requires --branch)
 #   -y, --yes              Skip confirmation prompt
@@ -24,7 +24,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - cursor-agent CLI installed
+#   - claude CLI installed
 
 set -euo pipefail
 
@@ -46,7 +46,7 @@ Usage:
 
 Options:
   -n, --iterations N     Max iterations (default: 20)
-  -m, --model MODEL      Model to use (default: opus-4.5-thinking)
+  -m, --model MODEL      Model to use (default: opus)
   --branch NAME          Create and work on a new branch
   --pr                   Open PR when complete (requires --branch)
   -y, --yes              Skip confirmation prompt
@@ -55,7 +55,7 @@ Options:
 Examples:
   ./ralph-loop.sh                                    # Interactive mode
   ./ralph-loop.sh -n 50                              # 50 iterations max
-  ./ralph-loop.sh -m gpt-5.2-high                    # Use GPT model
+  ./ralph-loop.sh -m sonnet                          # Use Sonnet model
   ./ralph-loop.sh --branch feature/api --pr -y      # Scripted PR workflow
   
 Environment:
@@ -173,7 +173,7 @@ main() {
   
   # Confirm before starting (unless -y flag)
   if [[ "$SKIP_CONFIRM" != "true" ]]; then
-    echo "This will run cursor-agent locally to work on this task."
+    echo "This will run claude CLI locally to work on this task."
     echo "The agent will be rotated when context fills up (~80k tokens)."
     echo ""
     echo "Tip: Use ralph-setup.sh for interactive model/option selection."

--- a/scripts/ralph-loop.sh
+++ b/scripts/ralph-loop.sh
@@ -115,7 +115,7 @@ done
 # =============================================================================
 
 main() {
-  # Resolve workspace
+  # Resolve workspace to absolute path
   if [[ -z "$WORKSPACE" ]]; then
     WORKSPACE="$(pwd)"
   elif [[ "$WORKSPACE" == "." ]]; then
@@ -123,12 +123,23 @@ main() {
   else
     WORKSPACE="$(cd "$WORKSPACE" && pwd)"
   fi
-  
-  local task_file="$WORKSPACE/RALPH_TASK.md"
-  
+
   # Show banner
   show_banner
-  
+
+  # Resolve to git root (exits with error if not in a git repo)
+  local git_root
+  if ! git_root=$(resolve_git_root "$WORKSPACE"); then
+    exit 1
+  fi
+  if [[ "$WORKSPACE" != "$git_root" ]]; then
+    echo "📂 Moving to git root: $git_root"
+    echo ""
+    WORKSPACE="$git_root"
+  fi
+
+  local task_file="$WORKSPACE/RALPH_TASK.md"
+
   # Check prerequisites
   if ! check_prerequisites "$WORKSPACE"; then
     exit 1

--- a/scripts/ralph-loop.sh
+++ b/scripts/ralph-loop.sh
@@ -127,17 +127,6 @@ main() {
   # Show banner
   show_banner
 
-  # Resolve to git root (exits with error if not in a git repo)
-  local git_root
-  if ! git_root=$(resolve_git_root "$WORKSPACE"); then
-    exit 1
-  fi
-  if [[ "$WORKSPACE" != "$git_root" ]]; then
-    echo "📂 Moving to git root: $git_root"
-    echo ""
-    WORKSPACE="$git_root"
-  fi
-
   local task_file="$WORKSPACE/RALPH_TASK.md"
 
   # Check prerequisites

--- a/scripts/ralph-loop.sh
+++ b/scripts/ralph-loop.sh
@@ -1,21 +1,23 @@
 #!/bin/bash
 # Ralph Wiggum: The Loop (CLI Mode)
 #
-# Runs claude CLI locally with stream-json parsing for accurate token tracking.
-# Handles context rotation via --resume when thresholds are hit.
+# Runs the selected CLI (claude or cursor-agent) with stream-json parsing for
+# accurate token tracking. Handles context rotation via resume when thresholds are hit.
 #
 # This script is for power users and scripting. For interactive use, see ralph-setup.sh.
 #
 # Usage:
 #   ./ralph-loop.sh                              # Start from current directory
 #   ./ralph-loop.sh /path/to/project             # Start from specific project
+#   ./ralph-loop.sh -c cursor-agent              # Use cursor-agent CLI
 #   ./ralph-loop.sh -n 50 -m opus                # Custom iterations and model
 #   ./ralph-loop.sh --branch feature/foo --pr   # Create branch and PR
 #   ./ralph-loop.sh -y                           # Skip confirmation (for scripting)
 #
 # Flags:
+#   -c, --cli TOOL         CLI tool: claude or cursor-agent (default: claude)
 #   -n, --iterations N     Max iterations (default: 20)
-#   -m, --model MODEL      Model to use (default: opus)
+#   -m, --model MODEL      Model to use (default depends on CLI tool)
 #   --branch NAME          Create and work on a new branch
 #   --pr                   Open PR when complete (requires --branch)
 #   -y, --yes              Skip confirmation prompt
@@ -24,7 +26,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - claude CLI installed
+#   - One of: claude CLI or cursor-agent CLI installed
 
 set -euo pipefail
 
@@ -48,8 +50,9 @@ Usage:
   ./ralph-loop.sh [options] [workspace]
 
 Options:
+  -c, --cli TOOL         CLI tool to use: claude or cursor-agent (default: claude)
   -n, --iterations N     Max iterations (default: 20)
-  -m, --model MODEL      Model to use (default: opus)
+  -m, --model MODEL      Model to use (default depends on CLI tool)
   --branch NAME          Create and work on a new branch
   --pr                   Open PR when complete (requires --branch)
   -y, --yes              Skip confirmation prompt
@@ -57,11 +60,13 @@ Options:
 
 Examples:
   ./ralph-loop.sh                                    # Interactive mode
+  ./ralph-loop.sh -c cursor-agent                    # Use cursor-agent CLI
   ./ralph-loop.sh -n 50                              # 50 iterations max
   ./ralph-loop.sh -m sonnet                          # Use Sonnet model
   ./ralph-loop.sh --branch feature/api --pr -y      # Scripted PR workflow
-  
+
 Environment:
+  CLI_TOOL               Override CLI tool (same as -c flag)
   RALPH_MODEL            Override default model (same as -m flag)
 
 For interactive setup with a beautiful UI, use ralph-setup.sh instead.
@@ -73,6 +78,10 @@ WORKSPACE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -c|--cli)
+      CLI_TOOL="$2"
+      shift 2
+      ;;
     -n|--iterations)
       MAX_ITERATIONS="$2"
       shift 2
@@ -163,6 +172,7 @@ main() {
   remaining=$((total_criteria - done_criteria))
   
   echo "Progress: $done_criteria / $total_criteria criteria complete ($remaining remaining)"
+  echo "CLI tool: $CLI_TOOL"
   echo "Model:    $MODEL"
   echo "Max iter: $MAX_ITERATIONS"
   [[ -n "$USE_BRANCH" ]] && echo "Branch:   $USE_BRANCH"

--- a/scripts/ralph-loop.sh
+++ b/scripts/ralph-loop.sh
@@ -33,6 +33,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source common functions
 source "$SCRIPT_DIR/ralph-common.sh"
 
+# Set up top-level interrupt handler (uses handler from ralph-common.sh)
+trap ralph_interrupt_handler INT TERM
+
 # =============================================================================
 # FLAG PARSING
 # =============================================================================

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -88,7 +88,7 @@ done
 # =============================================================================
 
 main() {
-  # Resolve workspace
+  # Resolve workspace to absolute path
   if [[ -z "$WORKSPACE" ]]; then
     WORKSPACE="$(pwd)"
   elif [[ "$WORKSPACE" == "." ]]; then
@@ -96,9 +96,7 @@ main() {
   else
     WORKSPACE="$(cd "$WORKSPACE" && pwd)"
   fi
-  
-  local task_file="$WORKSPACE/RALPH_TASK.md"
-  
+
   # Show banner
   echo "═══════════════════════════════════════════════════════════════════"
   echo "🐛 Ralph Wiggum: Single Iteration (Human-in-the-Loop)"
@@ -109,7 +107,20 @@ main() {
   echo ""
   echo "═══════════════════════════════════════════════════════════════════"
   echo ""
-  
+
+  # Resolve to git root (exits with error if not in a git repo)
+  local git_root
+  if ! git_root=$(resolve_git_root "$WORKSPACE"); then
+    exit 1
+  fi
+  if [[ "$WORKSPACE" != "$git_root" ]]; then
+    echo "📂 Moving to git root: $git_root"
+    echo ""
+    WORKSPACE="$git_root"
+  fi
+
+  local task_file="$WORKSPACE/RALPH_TASK.md"
+
   # Check prerequisites
   if ! check_prerequisites "$WORKSPACE"; then
     exit 1

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -5,9 +5,10 @@
 # Useful for testing your task definition before going AFK.
 #
 # Usage:
-#   ./ralph-once.sh                    # Run single iteration
-#   ./ralph-once.sh /path/to/project   # Run in specific project
-#   ./ralph-once.sh -m gpt-5.2-high    # Use specific model
+#   ./ralph-once.sh                         # Run single iteration
+#   ./ralph-once.sh /path/to/project        # Run in specific project
+#   ./ralph-once.sh -c cursor-agent         # Use cursor-agent CLI
+#   ./ralph-once.sh -m sonnet               # Use specific model
 #
 # After running:
 #   - Review the changes made
@@ -17,7 +18,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - claude CLI installed
+#   - One of: claude CLI or cursor-agent CLI installed
 
 set -euo pipefail
 
@@ -44,13 +45,15 @@ Usage:
   ./ralph-once.sh [options] [workspace]
 
 Options:
-  -m, --model MODEL      Model to use (default: opus)
+  -c, --cli TOOL         CLI tool to use: claude or cursor-agent (default: claude)
+  -m, --model MODEL      Model to use (default depends on CLI tool)
   -h, --help             Show this help
 
 Examples:
-  ./ralph-once.sh                # Run one iteration
-  ./ralph-once.sh -m sonnet      # Use Sonnet model
-  
+  ./ralph-once.sh                      # Run one iteration
+  ./ralph-once.sh -c cursor-agent      # Use cursor-agent CLI
+  ./ralph-once.sh -m sonnet            # Use Sonnet model
+
 After reviewing the results:
   - If satisfied: run ./ralph-setup.sh for full loop
   - If issues: fix them, update RALPH_TASK.md or guardrails, run again
@@ -62,6 +65,10 @@ WORKSPACE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -c|--cli)
+      CLI_TOOL="$2"
+      shift 2
+      ;;
     -m|--model)
       MODEL="$2"
       shift 2
@@ -119,6 +126,7 @@ main() {
   init_ralph_dir "$WORKSPACE"
   
   echo "Workspace: $WORKSPACE"
+  echo "CLI tool:  $CLI_TOOL"
   echo "Model:     $MODEL"
   echo ""
   

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -108,17 +108,6 @@ main() {
   echo "═══════════════════════════════════════════════════════════════════"
   echo ""
 
-  # Resolve to git root (exits with error if not in a git repo)
-  local git_root
-  if ! git_root=$(resolve_git_root "$WORKSPACE"); then
-    exit 1
-  fi
-  if [[ "$WORKSPACE" != "$git_root" ]]; then
-    echo "📂 Moving to git root: $git_root"
-    echo ""
-    WORKSPACE="$git_root"
-  fi
-
   local task_file="$WORKSPACE/RALPH_TASK.md"
 
   # Check prerequisites

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -17,7 +17,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - cursor-agent CLI installed
+#   - claude CLI installed
 
 set -euo pipefail
 
@@ -41,12 +41,12 @@ Usage:
   ./ralph-once.sh [options] [workspace]
 
 Options:
-  -m, --model MODEL      Model to use (default: opus-4.5-thinking)
+  -m, --model MODEL      Model to use (default: opus)
   -h, --help             Show this help
 
 Examples:
-  ./ralph-once.sh                        # Run one iteration
-  ./ralph-once.sh -m sonnet-4.5-thinking # Use Sonnet model
+  ./ralph-once.sh                # Run one iteration
+  ./ralph-once.sh -m sonnet      # Use Sonnet model
   
 After reviewing the results:
   - If satisfied: run ./ralph-setup.sh for full loop

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -26,6 +26,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source common functions
 source "$SCRIPT_DIR/ralph-common.sh"
 
+# Set up top-level interrupt handler (uses handler from ralph-common.sh)
+trap ralph_interrupt_handler INT TERM
+
 # =============================================================================
 # FLAG PARSING
 # =============================================================================

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -198,11 +198,6 @@ main() {
   if ! git_root=$(resolve_git_root "$workspace"); then
     exit 1
   fi
-  if [[ "$workspace" != "$git_root" ]]; then
-    echo "📂 Moving to git root: $git_root"
-    echo ""
-    workspace="$git_root"
-  fi
 
   local task_file="$workspace/RALPH_TASK.md"
 

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -193,12 +193,6 @@ main() {
   fi
   echo ""
 
-  # Resolve to git root (exits with error if not in a git repo)
-  local git_root
-  if ! git_root=$(resolve_git_root "$workspace"); then
-    exit 1
-  fi
-
   local task_file="$workspace/RALPH_TASK.md"
 
   # Check prerequisites

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -180,21 +180,32 @@ main() {
     workspace="$(pwd)"
   fi
   workspace="$(cd "$workspace" && pwd)"
-  
-  local task_file="$workspace/RALPH_TASK.md"
-  
+
   # Show banner
   echo ""
   show_header "🐛 Ralph Wiggum: Autonomous Development Loop"
   echo ""
-  
+
   if [[ "$HAS_GUM" == "true" ]]; then
     echo "  Using gum for enhanced UI ✨"
   else
     echo "  💡 Install gum for a better experience: https://github.com/charmbracelet/gum#installation"
   fi
   echo ""
-  
+
+  # Resolve to git root (exits with error if not in a git repo)
+  local git_root
+  if ! git_root=$(resolve_git_root "$workspace"); then
+    exit 1
+  fi
+  if [[ "$workspace" != "$git_root" ]]; then
+    echo "📂 Moving to git root: $git_root"
+    echo ""
+    workspace="$git_root"
+  fi
+
+  local task_file="$workspace/RALPH_TASK.md"
+
   # Check prerequisites
   if ! check_prerequisites "$workspace"; then
     exit 1

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -11,7 +11,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - claude CLI installed
+#   - One of: claude CLI or cursor-agent CLI installed
 #   - gum (optional, for enhanced UI): brew install gum
 
 set -euo pipefail
@@ -37,29 +37,75 @@ fi
 # GUM UI HELPERS
 # =============================================================================
 
-# Model options (Claude CLI model aliases)
-MODELS=(
+# CLI tool options
+CLI_TOOLS=(
+  "claude"
+  "cursor-agent"
+)
+
+# Model options per CLI tool
+CLAUDE_MODELS=(
   "opus"
   "sonnet"
   "haiku"
   "Custom..."
 )
 
+CURSOR_MODELS=(
+  "opus-4.5-thinking"
+  "sonnet-4.0"
+  "haiku-4.0"
+  "Custom..."
+)
+
+# Select CLI tool using gum or fallback
+select_cli_tool() {
+  if [[ "$HAS_GUM" == "true" ]]; then
+    gum choose --header "Select CLI tool:" "${CLI_TOOLS[@]}"
+  else
+    echo ""
+    echo "Select CLI tool:"
+    local i=1
+    for tool in "${CLI_TOOLS[@]}"; do
+      echo "  $i) $tool"
+      ((i++))
+    done
+    echo ""
+    read -p "Choice [1]: " choice
+    choice="${choice:-1}"
+
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 ]] && [[ "$choice" -le ${#CLI_TOOLS[@]} ]]; then
+      echo "${CLI_TOOLS[$((choice-1))]}"
+    else
+      echo "${CLI_TOOLS[0]}"
+    fi
+  fi
+}
+
 # Select model using gum or fallback
+# Uses global CLI_TOOL to determine which model list to show
 select_model() {
+  # Select appropriate model list based on CLI tool
+  local -a models
+  if [[ "$CLI_TOOL" == "cursor-agent" ]]; then
+    models=("${CURSOR_MODELS[@]}")
+  else
+    models=("${CLAUDE_MODELS[@]}")
+  fi
+
   if [[ "$HAS_GUM" == "true" ]]; then
     local selected
-    selected=$(gum choose --header "Select model:" "${MODELS[@]}")
-    
+    selected=$(gum choose --header "Select model:" "${models[@]}")
+
     if [[ "$selected" == "Custom..." ]]; then
-      selected=$(gum input --placeholder "Enter model name" --value "$DEFAULT_MODEL")
+      selected=$(gum input --placeholder "Enter model name" --value "${models[0]}")
     fi
     echo "$selected"
   else
     echo ""
     echo "Select model:"
     local i=1
-    for m in "${MODELS[@]}"; do
+    for m in "${models[@]}"; do
       if [[ "$m" == "Custom..." ]]; then
         echo "  $i) Custom (enter manually)"
       else
@@ -70,15 +116,15 @@ select_model() {
     echo ""
     read -p "Choice [1]: " choice
     choice="${choice:-1}"
-    
-    if [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 ]] && [[ "$choice" -le ${#MODELS[@]} ]]; then
-      local selected="${MODELS[$((choice-1))]}"
+
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [[ "$choice" -ge 1 ]] && [[ "$choice" -le ${#models[@]} ]]; then
+      local selected="${models[$((choice-1))]}"
       if [[ "$selected" == "Custom..." ]]; then
         read -p "Enter model name: " selected
       fi
       echo "$selected"
     else
-      echo "${MODELS[0]}"
+      echo "${models[0]}"
     fi
   fi
 }
@@ -239,8 +285,12 @@ main() {
     echo "Configure your Ralph session:"
   fi
   echo ""
-  
-  # 1. Select model
+
+  # 1. Select CLI tool
+  CLI_TOOL=$(select_cli_tool)
+  echo "✓ CLI tool: $CLI_TOOL"
+
+  # 2. Select model (options depend on CLI tool)
   MODEL=$(select_model)
   echo "✓ Model: $MODEL"
   
@@ -293,6 +343,7 @@ main() {
   
   echo "─────────────────────────────────────────────────────────────────"
   echo "Summary:"
+  echo "  • CLI tool:   $CLI_TOOL"
   echo "  • Model:      $MODEL"
   echo "  • Iterations: $MAX_ITERATIONS max"
   [[ -n "$USE_BRANCH" ]] && echo "  • Branch:     $USE_BRANCH"
@@ -311,6 +362,7 @@ main() {
   # ==========================================================================
   
   # Export settings for the loop
+  export CLI_TOOL
   export MODEL
   export MAX_ITERATIONS
   export USE_BRANCH

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -21,6 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source common functions
 source "$SCRIPT_DIR/ralph-common.sh"
 
+# Set up top-level interrupt handler (uses handler from ralph-common.sh)
+trap ralph_interrupt_handler INT TERM
+
 # =============================================================================
 # GUM DETECTION
 # =============================================================================

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -11,7 +11,7 @@
 # Requirements:
 #   - RALPH_TASK.md in the project root
 #   - Git repository
-#   - cursor-agent CLI installed
+#   - claude CLI installed
 #   - gum (optional, for enhanced UI): brew install gum
 
 set -euo pipefail
@@ -34,12 +34,11 @@ fi
 # GUM UI HELPERS
 # =============================================================================
 
-# Model options
+# Model options (Claude CLI model aliases)
 MODELS=(
-  "opus-4.5-thinking"
-  "sonnet-4.5-thinking"
-  "gpt-5.2-high"
-  "composer-1"
+  "opus"
+  "sonnet"
+  "haiku"
   "Custom..."
 )
 

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -87,11 +87,11 @@ select_model() {
 get_max_iterations() {
   if [[ "$HAS_GUM" == "true" ]]; then
     local value
-    value=$(gum input --header "Max iterations:" --placeholder "20" --value "20")
-    echo "${value:-20}"
+    value=$(gum input --header "Max iterations:" --placeholder "11" --value "11")
+    echo "${value:-11}"
   else
-    read -p "Max iterations [20]: " value
-    echo "${value:-20}"
+    read -p "Max iterations [11]: " value
+    echo "${value:-11}"
   fi
 }
 

--- a/scripts/stream-parser.sh
+++ b/scripts/stream-parser.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Ralph Wiggum: Stream Parser
 #
-# Parses cursor-agent stream-json output in real-time.
+# Parses Claude CLI stream-json output in real-time.
 # Tracks token usage, detects failures/gutter, writes to .ralph/ logs.
 #
 # Usage:
-#   cursor-agent -p --force --output-format stream-json "..." | ./stream-parser.sh /path/to/workspace
+#   claude -p --verbose --output-format stream-json "..." | ./stream-parser.sh /path/to/workspace
 #
 # Outputs to stdout:
 #   - ROTATE when threshold hit (80k tokens)
@@ -37,6 +37,11 @@ SHELL_OUTPUT_CHARS=0
 PROMPT_CHARS=0
 TOOL_CALLS=0
 WARN_SENT=0
+
+# Tool use/result tracking (Claude sends tool_use then tool_result separately)
+LAST_TOOL_NAME=""
+LAST_TOOL_INPUT=""
+LAST_TOOL_PATH=""
 
 # Estimate initial prompt size (Ralph prompt is ~2KB + file references)
 PROMPT_CHARS=3000
@@ -167,35 +172,42 @@ track_file_write() {
 # Process a single JSON line from stream
 process_line() {
   local line="$1"
-  
+
   # Skip empty lines
   [[ -z "$line" ]] && return
-  
+
   # Parse JSON type
   local type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || return
   local subtype=$(echo "$line" | jq -r '.subtype // empty' 2>/dev/null) || true
-  
+
   case "$type" in
+    # Handle session init (Claude: "system" with subtype "init")
     "system")
       if [[ "$subtype" == "init" ]]; then
         local model=$(echo "$line" | jq -r '.model // "unknown"' 2>/dev/null) || model="unknown"
         log_activity "SESSION START: model=$model"
       fi
       ;;
-      
+
+    # Handle assistant messages (Claude: "assistant" with .message.content)
     "assistant")
-      # Track assistant message characters
+      # Track assistant message characters - try both formats
       local text=$(echo "$line" | jq -r '.message.content[0].text // empty' 2>/dev/null) || text=""
+      if [[ -z "$text" ]]; then
+        # Also try .content[].text for some message formats
+        text=$(echo "$line" | jq -r '.content[0].text // empty' 2>/dev/null) || text=""
+      fi
+
       if [[ -n "$text" ]]; then
         local chars=${#text}
         ASSISTANT_CHARS=$((ASSISTANT_CHARS + chars))
-        
+
         # Check for completion sigil
         if [[ "$text" == *"<ralph>COMPLETE</ralph>"* ]]; then
           log_activity "✅ Agent signaled COMPLETE"
           echo "COMPLETE" 2>/dev/null || true
         fi
-        
+
         # Check for gutter sigil
         if [[ "$text" == *"<ralph>GUTTER</ralph>"* ]]; then
           log_activity "🚨 Agent signaled GUTTER (stuck)"
@@ -203,69 +215,102 @@ process_line() {
         fi
       fi
       ;;
-      
-    "tool_call")
-      if [[ "$subtype" == "started" ]]; then
-        TOOL_CALLS=$((TOOL_CALLS + 1))
-        
-      elif [[ "$subtype" == "completed" ]]; then
-        # Handle read tool completion
-        if echo "$line" | jq -e '.tool_call.readToolCall.result.success' > /dev/null 2>&1; then
-          local path=$(echo "$line" | jq -r '.tool_call.readToolCall.args.path // "unknown"' 2>/dev/null) || path="unknown"
-          local lines=$(echo "$line" | jq -r '.tool_call.readToolCall.result.success.totalLines // 0' 2>/dev/null) || lines=0
-          
-          local content_size=$(echo "$line" | jq -r '.tool_call.readToolCall.result.success.contentSize // 0' 2>/dev/null) || content_size=0
-          local bytes
-          if [[ $content_size -gt 0 ]]; then
-            bytes=$content_size
-          else
-            bytes=$((lines * 100))  # ~100 chars/line for code
-          fi
+
+    # Handle tool invocation start (Claude CLI format)
+    "tool_use")
+      TOOL_CALLS=$((TOOL_CALLS + 1))
+
+      # Extract tool name and input for matching with tool_result
+      LAST_TOOL_NAME=$(echo "$line" | jq -r '.name // empty' 2>/dev/null) || LAST_TOOL_NAME=""
+
+      # Extract path from input based on tool type
+      case "$LAST_TOOL_NAME" in
+        "Read")
+          LAST_TOOL_PATH=$(echo "$line" | jq -r '.input.file_path // empty' 2>/dev/null) || LAST_TOOL_PATH=""
+          ;;
+        "Write")
+          LAST_TOOL_PATH=$(echo "$line" | jq -r '.input.file_path // empty' 2>/dev/null) || LAST_TOOL_PATH=""
+          ;;
+        "Edit")
+          LAST_TOOL_PATH=$(echo "$line" | jq -r '.input.file_path // empty' 2>/dev/null) || LAST_TOOL_PATH=""
+          ;;
+        "Bash")
+          LAST_TOOL_INPUT=$(echo "$line" | jq -r '.input.command // empty' 2>/dev/null) || LAST_TOOL_INPUT=""
+          ;;
+        "Glob"|"Grep")
+          LAST_TOOL_PATH=$(echo "$line" | jq -r '.input.pattern // empty' 2>/dev/null) || LAST_TOOL_PATH=""
+          ;;
+      esac
+      ;;
+
+    # Handle tool execution result (Claude CLI format)
+    "tool_result")
+      local output=$(echo "$line" | jq -r '.output // empty' 2>/dev/null) || output=""
+      local content=$(echo "$line" | jq -r '.content // empty' 2>/dev/null) || content=""
+      local result_text="${output}${content}"
+      local bytes=${#result_text}
+
+      case "$LAST_TOOL_NAME" in
+        "Read")
           BYTES_READ=$((BYTES_READ + bytes))
-          
           local kb=$(echo "scale=1; $bytes / 1024" | bc 2>/dev/null || echo "$((bytes / 1024))")
-          log_activity "READ $path ($lines lines, ~${kb}KB)"
-          
-        # Handle write tool completion
-        elif echo "$line" | jq -e '.tool_call.writeToolCall.result.success' > /dev/null 2>&1; then
-          local path=$(echo "$line" | jq -r '.tool_call.writeToolCall.args.path // "unknown"' 2>/dev/null) || path="unknown"
-          local lines=$(echo "$line" | jq -r '.tool_call.writeToolCall.result.success.linesCreated // 0' 2>/dev/null) || lines=0
-          local bytes=$(echo "$line" | jq -r '.tool_call.writeToolCall.result.success.fileSize // 0' 2>/dev/null) || bytes=0
+          log_activity "READ $LAST_TOOL_PATH (~${kb}KB)"
+          ;;
+        "Write")
           BYTES_WRITTEN=$((BYTES_WRITTEN + bytes))
-          
           local kb=$(echo "scale=1; $bytes / 1024" | bc 2>/dev/null || echo "$((bytes / 1024))")
-          log_activity "WRITE $path ($lines lines, ${kb}KB)"
-          
-          # Track for thrashing detection
-          track_file_write "$path"
-          
-        # Handle shell tool completion
-        elif echo "$line" | jq -e '.tool_call.shellToolCall.result' > /dev/null 2>&1; then
-          local cmd=$(echo "$line" | jq -r '.tool_call.shellToolCall.args.command // "unknown"' 2>/dev/null) || cmd="unknown"
-          local exit_code=$(echo "$line" | jq -r '.tool_call.shellToolCall.result.exitCode // 0' 2>/dev/null) || exit_code=0
-          
-          local stdout=$(echo "$line" | jq -r '.tool_call.shellToolCall.result.stdout // ""' 2>/dev/null) || stdout=""
-          local stderr=$(echo "$line" | jq -r '.tool_call.shellToolCall.result.stderr // ""' 2>/dev/null) || stderr=""
-          local output_chars=$((${#stdout} + ${#stderr}))
-          SHELL_OUTPUT_CHARS=$((SHELL_OUTPUT_CHARS + output_chars))
-          
+          log_activity "WRITE $LAST_TOOL_PATH (~${kb}KB)"
+          track_file_write "$LAST_TOOL_PATH"
+          ;;
+        "Edit")
+          # Edit is typically smaller changes
+          BYTES_WRITTEN=$((BYTES_WRITTEN + bytes))
+          log_activity "EDIT $LAST_TOOL_PATH"
+          track_file_write "$LAST_TOOL_PATH"
+          ;;
+        "Bash")
+          SHELL_OUTPUT_CHARS=$((SHELL_OUTPUT_CHARS + bytes))
+          # Try to extract exit code from output if present
+          local exit_code=0
+          if [[ "$result_text" == *"exit code"* ]] || [[ "$result_text" == *"Error"* ]] || [[ "$result_text" == *"error"* ]]; then
+            # Check for common error patterns
+            if [[ "$result_text" == *"exit code 1"* ]] || [[ "$result_text" == *"FAILED"* ]]; then
+              exit_code=1
+            fi
+          fi
+
           if [[ $exit_code -eq 0 ]]; then
-            if [[ $output_chars -gt 1024 ]]; then
-              log_activity "SHELL $cmd → exit 0 (${output_chars} chars output)"
+            if [[ $bytes -gt 1024 ]]; then
+              log_activity "BASH $LAST_TOOL_INPUT → ok (${bytes} chars)"
             else
-              log_activity "SHELL $cmd → exit 0"
+              log_activity "BASH $LAST_TOOL_INPUT → ok"
             fi
           else
-            log_activity "SHELL $cmd → exit $exit_code"
-            track_shell_failure "$cmd" "$exit_code"
+            log_activity "BASH $LAST_TOOL_INPUT → failed"
+            track_shell_failure "$LAST_TOOL_INPUT" "$exit_code"
           fi
-        fi
-        
-        # Check thresholds after each tool call
-        check_gutter
-      fi
+          ;;
+        "Glob"|"Grep")
+          BYTES_READ=$((BYTES_READ + bytes))
+          log_activity "SEARCH $LAST_TOOL_PATH (~${bytes} chars)"
+          ;;
+        *)
+          # Unknown tool, just track as read
+          BYTES_READ=$((BYTES_READ + bytes))
+          log_activity "TOOL $LAST_TOOL_NAME (~${bytes} chars)"
+          ;;
+      esac
+
+      # Reset tracking
+      LAST_TOOL_NAME=""
+      LAST_TOOL_INPUT=""
+      LAST_TOOL_PATH=""
+
+      # Check thresholds after each tool result
+      check_gutter
       ;;
-      
+
+    # Handle session end
     "result")
       local duration=$(echo "$line" | jq -r '.duration_ms // 0' 2>/dev/null) || duration=0
       local tokens=$(calc_tokens)


### PR DESCRIPTION
Adapt the Ralph Wiggum framework to work with Claude Code CLI instead of cursor-agent. This involves changes to:

- Command invocation: cursor-agent → claude -p --verbose
- Stream parser: Support Claude's tool_use/tool_result message types
- Directory structure: .cursor/ → .claude/
- Model names: Use Claude aliases (opus, sonnet, haiku)
- Documentation: Update README and all script comments

The stream parser now handles Claude's JSON format which uses separate tool_use and tool_result messages instead of cursor's tool_call with started/completed subtypes.