### PR TITLE
fix Ralph checkpoint flow, branch selection, and parser diagnostics

### DIFF
--- a/scripts/ralph-common.sh
+++ b/scripts/ralph-common.sh
@@ -62,6 +62,63 @@ sedi() {
   fi
 }
 
+# Collect stageable paths without recursing into submodules.
+# This avoids failures in repos where nested submodule metadata is incomplete.
+collect_stageable_paths() {
+  local workspace="${1:-.}"
+  local status_output line path
+
+  status_output=$(git -C "$workspace" -c submodule.recurse=false status --porcelain --ignore-submodules=all 2>/dev/null || true)
+  [[ -z "$status_output" ]] && return 0
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    path="${line:3}"
+
+    # Handle rename/copy entries in porcelain v1 format: old -> new
+    if [[ "$path" == *" -> "* ]]; then
+      path="${path##* -> }"
+    fi
+
+    [[ -n "$path" ]] && printf '%s\n' "$path"
+  done <<< "$status_output"
+}
+
+# Create a checkpoint commit when there are pending changes.
+# Stages files path-by-path so one problematic path does not block the loop.
+checkpoint_commit_if_needed() {
+  local workspace="${1:-.}"
+  local commit_message="$2"
+  local -a paths=()
+  local path
+
+  while IFS= read -r path; do
+    [[ -n "$path" ]] && paths+=("$path")
+  done < <(collect_stageable_paths "$workspace")
+
+  if [[ ${#paths[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  echo "📦 Committing uncommitted changes..."
+
+  local staged_any=false
+  for path in "${paths[@]}"; do
+    if git -C "$workspace" add -- "$path" 2>/dev/null; then
+      staged_any=true
+    else
+      echo "   ⚠️  Skipping unstageable path: $path"
+    fi
+  done
+
+  if [[ "$staged_any" != "true" ]]; then
+    echo "   ⚠️  Could not stage checkpoint changes; continuing without checkpoint commit."
+    return 0
+  fi
+
+  git -C "$workspace" commit -m "$commit_message" >/dev/null 2>&1 || true
+}
+
 # Get the .ralph directory for a workspace
 get_ralph_dir() {
   local workspace="${1:-.}"
@@ -409,10 +466,11 @@ You are already in a git repository. Work HERE, not in a subdirectory:
 Ralph's strength is state-in-git, not LLM memory. Commit early and often:
 
 1. After completing each criterion, commit your changes:
-   \`git add -A && git commit -m 'ralph: implement state tracker'\`
-   \`git add -A && git commit -m 'ralph: fix async race condition'\`
-   \`git add -A && git commit -m 'ralph: add CLI adapter with commander'\`
+   \`git add -- <paths-you-changed> && git commit -m 'ralph: implement state tracker'\`
+   \`git add -- <paths-you-changed> && git commit -m 'ralph: fix async race condition'\`
+   \`git add -- <paths-you-changed> && git commit -m 'ralph: add CLI adapter with commander'\`
    Always describe what you actually did - never use placeholders like '<description>'
+   Avoid \`git add -A\` when submodules exist; it can fail due to submodule metadata issues.
 2. After any significant code change (even partial): commit with descriptive message
 3. Before any risky refactor: commit current state as checkpoint
 4. Push after every 2-3 commits: \`git push\`
@@ -523,7 +581,7 @@ run_iteration() {
   # Start parser in background, reading from cursor-agent
   # Parser outputs to fifo, we read signals from fifo
   (
-    eval "$cmd \"$prompt\"" 2>&1 | "$script_dir/stream-parser.sh" "$workspace" > "$fifo"
+    eval "$cmd \"$prompt\"" 2>&1 | WARN_THRESHOLD="$WARN_THRESHOLD" ROTATE_THRESHOLD="$ROTATE_THRESHOLD" "$script_dir/stream-parser.sh" "$workspace" > "$fifo"
   ) &
   local agent_pid=$!
   
@@ -590,19 +648,15 @@ run_ralph_loop() {
   local workspace="$1"
   local script_dir="${2:-$(dirname "${BASH_SOURCE[0]}")}"
   
-  # Commit any uncommitted work first
+  # Create/switch branch first so checkpoint commits land on the intended branch.
   cd "$workspace"
-  if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
-    echo "📦 Committing uncommitted changes..."
-    git add -A
-    git commit -m "ralph: initial commit before loop" || true
-  fi
-  
-  # Create branch if requested
   if [[ -n "$USE_BRANCH" ]]; then
     echo "🌿 Creating branch: $USE_BRANCH"
     git checkout -b "$USE_BRANCH" 2>/dev/null || git checkout "$USE_BRANCH"
   fi
+
+  # Commit any uncommitted work after branch selection.
+  checkpoint_commit_if_needed "$workspace" "ralph: initial commit before loop"
   
   echo ""
   echo "🚀 Starting Ralph loop..."

--- a/scripts/ralph-once.sh
+++ b/scripts/ralph-once.sh
@@ -152,11 +152,7 @@ main() {
   
   # Commit any uncommitted work first
   cd "$WORKSPACE"
-  if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
-    echo "📦 Committing uncommitted changes..."
-    git add -A
-    git commit -m "ralph: checkpoint before single iteration" || true
-  fi
+  checkpoint_commit_if_needed "$WORKSPACE" "ralph: checkpoint before single iteration"
   
   echo ""
   echo "🚀 Running single iteration..."

--- a/scripts/ralph-setup.sh
+++ b/scripts/ralph-setup.sh
@@ -347,6 +347,14 @@ main() {
     echo ""
     echo "🧪 Running single iteration first..."
     echo ""
+
+    # Keep behavior consistent with full loop: branch selection before checkpoint commit.
+    cd "$workspace"
+    if [[ -n "$USE_BRANCH" ]]; then
+      echo "🌿 Creating branch: $USE_BRANCH"
+      git checkout -b "$USE_BRANCH" 2>/dev/null || git checkout "$USE_BRANCH"
+    fi
+    checkpoint_commit_if_needed "$workspace" "ralph: initial commit before loop"
     
     # Run just one iteration
     local signal

--- a/scripts/stream-parser.sh
+++ b/scripts/stream-parser.sh
@@ -25,9 +25,9 @@ RALPH_DIR="$WORKSPACE/.ralph"
 # Ensure .ralph directory exists
 mkdir -p "$RALPH_DIR"
 
-# Thresholds
-WARN_THRESHOLD=70000
-ROTATE_THRESHOLD=80000
+# Thresholds (can be overridden via environment variables)
+WARN_THRESHOLD="${WARN_THRESHOLD:-70000}"
+ROTATE_THRESHOLD="${ROTATE_THRESHOLD:-80000}"
 
 # Tracking state
 BYTES_READ=0
@@ -37,6 +37,7 @@ SHELL_OUTPUT_CHARS=0
 PROMPT_CHARS=0
 TOOL_CALLS=0
 WARN_SENT=0
+NON_JSON_LINES=0
 
 # Estimate initial prompt size (Ralph prompt is ~2KB + file references)
 PROMPT_CHARS=3000
@@ -204,8 +205,19 @@ process_line() {
   # Skip empty lines
   [[ -z "$line" ]] && return
   
-  # Parse JSON type
-  local type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || return
+  # Parse JSON type; stream-json failures often surface as plain stderr lines.
+  local type
+  type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null || true)
+  if [[ -z "$type" ]]; then
+    local trimmed="${line//$'\r'/}"
+    if [[ -n "${trimmed//[[:space:]]/}" ]]; then
+      NON_JSON_LINES=$((NON_JSON_LINES + 1))
+      log_error "AGENT STDERR: $trimmed"
+      log_activity "⚠️ AGENT STDERR: $trimmed"
+    fi
+    return
+  fi
+
   local subtype=$(echo "$line" | jq -r '.subtype // empty' 2>/dev/null) || true
   
   case "$type" in
@@ -347,6 +359,12 @@ main() {
     fi
   done
   
+  # If the stream was not valid JSON, fail fast instead of silently looping.
+  if [[ $NON_JSON_LINES -gt 0 ]]; then
+    log_error "STREAM FORMAT ERROR: saw $NON_JSON_LINES non-JSON line(s); signaling GUTTER."
+    echo "GUTTER" 2>/dev/null || true
+  fi
+
   # Final token status
   log_token_status
 }


### PR DESCRIPTION
## Summary
- make checkpoint commits submodule-safe by staging changed paths individually instead of using `git add -A`
- ensure `Work on new branch` behavior is honored by creating/switching branches before checkpoint commits in both full-loop and single-iteration flows
- wire `WARN_THRESHOLD`/`ROTATE_THRESHOLD` from `ralph-common.sh` into `stream-parser.sh` and make parser thresholds env-overridable
- log non-JSON `cursor-agent` stderr lines to `.ralph/errors.log`/`.ralph/activity.log` and emit `GUTTER` on invalid stream format to avoid silent no-progress loops

## Test plan
- [x] `bash -n scripts/ralph-common.sh`
- [x] `bash -n scripts/ralph-setup.sh`
- [x] `bash -n scripts/ralph-once.sh`
- [x] `bash -n scripts/stream-parser.sh`
- [x] validated helper smoke test: `source scripts/ralph-common.sh && collect_stageable_paths .`
- [x] manually verified branch-first checkpoint logic in code paths for both full loop and single-iteration mode

Made with [Cursor](https://cursor.com)